### PR TITLE
Support pre-ES-2015 browsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,13 @@ dropped. If you require this level of support, please use version [`0.3.0`].
 
 ## Browser Support
 
-* IE `9+` (Before `Edge` requires `Promise` polyfill)
-* Firefox `4+` (Before `29` requires `Promise` polyfill)
-* Safari `3+` (Before `7.1` requires `Promise` polyfill)
-* Chrome `*` (Before `33` requires `Promise` polyfill)
-* Opera `*` (Before `20` requires `Promise` polyfill)
+* IE/Edge `9+`
+* Firefox `4+`
+* Safari `3+`
+* Chrome `*`
+* Opera `*`
+
+We use [`any-promise`] to support any ES-2015-compatible Promise library or polyfill.
 
 ## Testing
 
@@ -57,4 +59,5 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
 [`domready`]: https://github.com/ded/domready "domReady"
+[`any-promise`]: https://github.com/kevinbeaty/any-promise "any-promise"
 [`0.3.0`]: https://github.com/KenPowers/dr-promise/tree/v0.3.0 "v0.3.0"

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,1 +1,3 @@
+var Promise = require('any-promise');
+
 module.exports = new Promise(require('domready'));

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "homepage": "https://github.com/kenpowers/dr-promise#readme",
   "dependencies": {
+    "any-promise": "^0.1.0",
     "domready": "^1.0.8"
   },
   "devDependencies": {


### PR DESCRIPTION
[Not all](http://caniuse.com/#search=promise) commonly-used browsers support promises natively. To get your lib to work in IE I have to install a global shim – which [isn’t a best practice](https://github.com/sindresorhus/object-assign/issues/10#issuecomment-65065859).

There are two reasonable options to deal with this:
- use a non-global shim like _[es6-promise](http://npm.im/es6-promise)_;
- use _[any-promise](http://npm.im/any-promise)_ to get any already-installed spec-compliant non-global polyfill.

I went with the second option.
